### PR TITLE
notify_url, return_url are not required

### DIFF
--- a/lib/china_pay/alipay.rb
+++ b/lib/china_pay/alipay.rb
@@ -14,7 +14,7 @@ module ChinaPay
 
 
         ATTR_REQUIRED = [:service, :partner, :_input_charset,
-          :sign_type, :sign, :notify_url, :return_url,
+          :sign_type, :sign,
           :out_trade_no, :subject, :payment_type, :seller_email
         ]
 


### PR DESCRIPTION
notify_url and return_url are optional according to official document.
Actually, we can still get trade status via single_trade_query API.
